### PR TITLE
Revert "Merge pull request #442 from ruby/lock-minitest"

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         ruby-version: '3.0'
     - name: Install dependencies
-      run: gem install minitest -v "5.15.0"
+      run: gem install minitest
     - name: Run test
       env:
         COVERALLS: "yes"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Install dependencies
-      run: gem install minitest -v "5.15.0"
+      run: gem install minitest
     - name: Run test
       run: ruby -Ilib exe/rake


### PR DESCRIPTION
This reverts commit 2cda97690c3f8a2d21bb8e87291b2852b488f5c6, reversing changes made to 73a21161bbd0db02804bbd11606a7529e2a0aaa2.

Reason: The `minitest` gem was locked for Ruby 2.2 by #442, but support for Ruby 2.2 is dropped by #492. So there is no need to lock `minitest` now.